### PR TITLE
Possible incorrect reference to a figure

### DIFF
--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -2208,10 +2208,10 @@ We have seen this Chisel one-liner before:
   \centering
   \includegraphics[scale=\scale]{figures/fsm-rising}
   \caption{A rising edge detector (Mealy type FSM).}
-  \label{fig:rising}
+  \label{fig:fsm-rising}
 \end{figure}
 
-Figure~\ref{fig:rising} shows the schematic of the rising edge detector.
+Figure~\ref{fig:fsm-rising} shows the schematic of the rising edge detector.
 The output becomes 1 for one clock cycle when the current input is 1
 and the input in the last clock cycle was 0.
 The state register is just a single D flip-flop where the next state


### PR DESCRIPTION
"Figure 7.7 shows ..." on page 62 of the PDF version may be "FIgure 7.3 shows ...".
The duplication of `\label{fig:rising}` seems to be the cause of this problem.