### PR TITLE
Correct usage of RoCC and DANA

### DIFF
--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -3527,9 +3527,9 @@ generator written in Chisel~~\cite{OpenSoC:ispass2016}. It is intended to provid
 system-on-chip for large-scale design exploration. The NoC itself is a state-of-the-art design with wormhole routing, credits for flow control, and virtual channels.
 OpenSoC Fabric is still using Chisel~2.
 
-\item[\myref{https://github.com/bu-icsg/xfiles-dana}{RoCC}] is a neural network accelerator
-that integrates with the RISC-V Rocket processor~\cite{RoCC:2015}.
-RoCC supports inference and learning.
+\item[\myref{https://github.com/bu-icsg/xfiles-dana}{DANA}] is a neural network accelerator
+that integrates with the RISC-V Rocket processor using the Rocket Custom Coprocessor (RoCC) interface~\cite{RoCC:2015}.
+DANA supports inference and learning.
 
 \end{description}
 


### PR DESCRIPTION
Fix mention of RoCC to really be DANA (DANA was an accelerator built
that uses the RoCC interface/socket). I think this originates from
some confusing language on the original Chisel website.