### PR TITLE
update Scala to 2.12.11 and Chisel to latest verison

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,46 @@
+def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  switch to support our anonymous Bundle definitions:
+    //  https://github.com/scala/bug/issues/10047
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
+      case _ => Seq("-Xsource:2.11")
+    }
+  }
+}
 
-scalaVersion := "2.11.7"
+def javacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // Scala 2.12 requires Java 8. We continue to generate
+    //  Java 7 compatible code for Scala 2.11
+    //  for compatibility with old clients.
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
+        Seq("-source", "1.7", "-target", "1.7")
+      case _ =>
+        Seq("-source", "1.8", "-target", "1.8")
+    }
+  }
+}
 
-// libraryDependencies += "edu.berkeley.cs" %% "chisel" % "latest.release"
-
-// libraryDependencies += "edu.berkeley.cs" %% "chisel" % "2.2.38"
+scalaVersion := "2.12.11"
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases")
 )
 
-scalacOptions := Seq("-deprecation")
+// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
+val defaultVersions = Map(
+  "chisel3" -> "3.3.+",
+  "chisel-iotesters" -> "1.4.+"
+  )
 
-libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.2.2"
-libraryDependencies += "edu.berkeley.cs" %% "chisel-iotesters" % "1.3.2"
+libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {
+  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
+
+javacOptions ++= javacOptionsVersion(scalaVersion.value)
+


### PR DESCRIPTION
As a book that keeps pace with the times, we should follow Chisel ’s latest developments.
I have not found any problems affecting the compilation after upgrading.