### PR TITLE
Add document outline to PDF

### DIFF
--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -76,6 +76,7 @@
   urlcolor   = blue,
   colorlinks = true,
   bookmarks=true,
+  pdfpagemode=UseOutlines,
 }
 \fi
 


### PR DESCRIPTION
Having a document outline makes for a much better reading experience, as the reader can easily jump between sections.

![outline](https://user-images.githubusercontent.com/3614/83460149-119ab000-a4a9-11ea-84d4-936d99c40906.png)
