### PR TITLE
Fix typo in components.scala

### DIFF
--- a/src/main/scala/components.scala
+++ b/src/main/scala/components.scala
@@ -160,7 +160,7 @@ class Fetch extends Module {
     val instr = Output(UInt(32.W))
     val pc = Output(UInt(32.W))
   })
-  // ... Implementation od fetch
+  // ... Implementation of fetch
 }
 //- end
 


### PR DESCRIPTION
It should read "Implementation of fetch".