### PR TITLE
Enable PDF sidebar table of contents and metadata

### DIFF
--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -36,7 +36,7 @@
 
 
 \usepackage{pslatex} % -- times instead of computer modern, especially for the plain article class
-\usepackage[colorlinks=true,bookmarks=false]{hyperref}
+\usepackage[colorlinks=true,bookmarks=true]{hyperref}
 \usepackage{booktabs}
 \usepackage{graphicx}
 \usepackage{xcolor}

--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -34,9 +34,12 @@
 
 
 
-
 \usepackage{pslatex} % -- times instead of computer modern, especially for the plain article class
-\usepackage[colorlinks=true,bookmarks=true]{hyperref}
+\usepackage[pdftex,
+            pdfauthor={Martin Schoeberl},
+            pdftitle={Digital Design with Chisel},
+            colorlinks=true,bookmarks=true]{hyperref}
+
 \usepackage{booktabs}
 \usepackage{graphicx}
 \usepackage{xcolor}


### PR DESCRIPTION
This enables PDF reader sidebar table of contents.

Tested in mac:

![image](https://user-images.githubusercontent.com/20382/151975599-fb5c7d9b-50df-4ecf-b380-2598db420111.png)

Also added the PDF metadata to the generated file.

![image](https://user-images.githubusercontent.com/20382/151986019-a4740259-b8d2-4967-974a-376014ac2805.png)


Fixes #35 