### PR TITLE
Typo fix in Chapter 3

### DIFF
--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -1540,7 +1540,7 @@ You can simply print out the string for testing.
 \shortlist{code/generate_string.txt}
 
 \noindent This form of output is popular when showing small Chisel examples in
-\myref{https://scastie.scala-lang.org/}{Scastie}, a web based Scala compiler and runtim.
+\myref{https://scastie.scala-lang.org/}{Scastie}, a web based Scala compiler and runtime.
 See as an example of the
 \myref{https://scastie.scala-lang.org/schoeberl/SN7rDb9iS027ORiWqXMGsQ/6}{Hello World on Scastie}.
 


### PR DESCRIPTION
Typo [3.1.3 last second sentence] [line1543]: "runtim" -> "rumtime"