### PR TITLE
Fix `MultiClockMemory` for Chisel > 3.6.0

### DIFF
--- a/src/main/scala/MultiClockMemory.scala
+++ b/src/main/scala/MultiClockMemory.scala
@@ -20,16 +20,7 @@ class MultiClockMemory(ports: Int, n: Int = 1024, w: Int = 32) extends Module {
 
   for (i <- 0 until ports) {
     val p = io.ps(i)
-    withClock(p.clk.asClock) {
-      val datao = WireDefault(0.U(w.W))
-      when(p.en) {
-        datao := ram(p.addr)
-        when(p.we) {
-          ram(p.addr) := p.datai
-        }
-      }
-      p.datao := datao
-    }
+    p.datao := ram.readWrite(p.addr, p.datai, p.en, p.we, p.clk.asClock)
   }
 }
 //- end


### PR DESCRIPTION
Chisel3 > 3.6.0 requires explicitly passing the write clocks to individual ports of a multi-clock memory. This is hereby fixed in the example code. Note that this changes the memory's behavior from outputting zero when nothing is read to outputting a don't care.