### PR TITLE
Add missing period in when{}.otherwise{} snippets

### DIFF
--- a/slides-tutorial/unit2.tex
+++ b/slides-tutorial/unit2.tex
@@ -216,7 +216,7 @@ initReg := initReg + 1.U
 \begin{itemize}
 \item A Multiplexer selects between alternatives
 \item So common that Chisel provides a construct for it
-\item Selects \code{a} when \code{sel} is \code{true.B} otherwise \code{b}
+\item Selects \code{a} when \code{sel} is \code{true.B} .otherwise \code{b}
 \item Could be implemented with conditional updates
 \item Automagical type selection on input types
 \end{itemize}

--- a/slides/01_intro.tex
+++ b/slides/01_intro.tex
@@ -700,7 +700,7 @@ A single bit can be extracted as follows:
 \begin{itemize}
 \item A Multiplexer selects between alternatives
 \item So common that Chisel provides a construct for it
-\item Selects \code{a} when \code{sel} is \code{true.B} otherwise \code{b}
+\item Selects \code{a} when \code{sel} is \code{true.B} .otherwise \code{b}
 \end{itemize}
 \shortlist{../code/mux.txt}
 \end{frame}

--- a/slides/02_basic.tex
+++ b/slides/02_basic.tex
@@ -198,7 +198,7 @@ A single bit can be extracted as follows:
 \begin{itemize}
 \item A Multiplexer selects between alternatives
 \item So common that Chisel provides a construct for it
-\item Selects \code{a} when \code{sel} is \code{true.B} otherwise \code{b}
+\item Selects \code{a} when \code{sel} is \code{true.B} .otherwise \code{b}
 \end{itemize}
 \shortlist{../code/mux.txt}
 \end{frame}

--- a/src/main/scala/ArbiterTree.scala
+++ b/src/main/scala/ArbiterTree.scala
@@ -34,7 +34,7 @@ class ArbiterTree[T <: Data: Manifest](n: Int, private val gen: T) extends Arbit
         when (a.valid) {
           regData := a.bits
           regState := hasA
-        } otherwise {
+        } .otherwise {
           regState := idleB
         }
       }
@@ -42,7 +42,7 @@ class ArbiterTree[T <: Data: Manifest](n: Int, private val gen: T) extends Arbit
         when (b.valid) {
           regData := b.bits
           regState := hasB
-        } otherwise {
+        } .otherwise {
           regState := idleA
         }
       }

--- a/src/main/scala/ArbiterTreeExperiements.scala
+++ b/src/main/scala/ArbiterTreeExperiements.scala
@@ -117,7 +117,7 @@ class ArbiterTreeExperiments[T <: Data: Manifest](n: Int, private val gen: T) ex
         when (a.valid) {
           regData := a.bits
           regState := hasA
-        } otherwise {
+        } .otherwise {
           regState := idleB
         }
       }
@@ -125,7 +125,7 @@ class ArbiterTreeExperiments[T <: Data: Manifest](n: Int, private val gen: T) ex
         when (b.valid) {
           regData := b.bits
           regState := hasB
-        } otherwise {
+        } .otherwise {
           regState := idleA
         }
       }

--- a/src/main/scala/ShiftRegister.scala
+++ b/src/main/scala/ShiftRegister.scala
@@ -36,7 +36,7 @@ class ShiftRegister extends Module {
   val loadReg = RegInit(0.U(4.W))
   when (load) {
     loadReg := d
-  } otherwise  {
+  } .otherwise  {
     loadReg := 0.U ## loadReg(3, 1)
   }
   val serOut = loadReg(0)


### PR DESCRIPTION
In some places, the `when{}.otherwise{}` chain is missing a period. This PR adds the missing period in those snippets.