### PR TITLE
Smoothing up the build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ checkref:
 fig:
 	make -C figures
 
-book:
+book: gencode fig
 	pdflatex $(DOC)
 	pdflatex $(DOC)
 	bibtex $(DOC)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ book: gencode fig
 	pdflatex $(DOC)
 	pdflatex $(DOC)
 
-genslides:
+genslides: gencode fig
 	cd slides; ./doslides.sh
 
 veryclean:

--- a/slides-tutorial/Makefile
+++ b/slides-tutorial/Makefile
@@ -3,7 +3,10 @@
 
 all:
 	pdflatex program
-	pdflatex intro
+	pdflatex features
+	pdflatex chisel-10min
+	pdflatex chisel-30min
+	pdflatex unit1
 	pdflatex unit2
 	pdflatex unit3
 	pdflatex unit4

--- a/slides/common/slides_common.tex
+++ b/slides/common/slides_common.tex
@@ -1,4 +1,4 @@
-\documentclass[xcolor=pdflatex,dvipsnames,table]{beamer}
+\documentclass[xcolor={dvipsnames,table}]{beamer}
 \usepackage{epsfig,graphicx}
 \usepackage{palatino}
 \usepackage{fancybox}


### PR DESCRIPTION
I added some minor changes:
* Pass options to the `xcolor` packages as explained [here](https://tex.stackexchange.com/questions/713015/unknown-option-pdflatex-for-package-xcolor-edef) to avoid errors/warning when running modern TexLive versions.
* Add prerequisites to the `book` and `genslides` target so that they can be build indepently.
* Change the `Makefile` in the `slides-tutorial` folder to build as many files as possible.