### PR TITLE
Minor TeX issues

### DIFF
--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -6665,7 +6665,7 @@ The accumulator and the register file are in our current implementation
 to implement 16-bit or 64-bit versions of Leros.}
 
 
-Table~\ref{tab: Leros:isa} shows the instruction set of Leros.
+Table~\ref{tab:leros:isa} shows the instruction set of Leros.
 \code{A} represents the accumulator, \code{PC} is the program counter,
 \code{i} is an immediate value (0 to 255), \code{Rn} a register
 \code{n} (0 to 255), \code{o} a branch offset relative to the \code{PC},
@@ -7724,7 +7724,7 @@ of the code.
 
 \longlist{code/vhdl_adder.txt}{A simple component in VHDL.}{lst:vhdl:adder}
 
-Listing~\ref{lst:v:ch:adder} shows a simple adder~\footnote{We should never use
+Listing~\ref{lst:v:ch:adder} shows a simple adder\footnote{We should never use
 such small components in real designs when the code that defines the function is just a few lines.
 In this example, just one line. However, we keep it short for the presentation
 of the concept of a component.}
@@ -7744,7 +7744,7 @@ equally. However, the current practice is to stick to lower cases for identifier
 \longlist{code/v_adder.txt}{A simple component in Verilog.}{lst:v:adder}
 
 Listing~\ref{lst:v:adder} shows the adder component in Verilog. Similar to Chisel,
-a component is also called a module.~\footnote{In fact, the naming in Chisel
+a component is also called a module.\footnote{In fact, the naming in Chisel
 was inspired by Verilog.}
 The adder has two 8-bit inputs and one 8-bit output.
 The \code{assign} statement is a concurrent statement that continuously

--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -6169,7 +6169,7 @@ and a network-on-chip with an OCP interface.
 \subsection{Further Bus Specifications}
 
 The Avalon \cite{soc:avalon} interface specification is provided by
-Intel for a system-on-a-programmable-chip interconnection.
+Intel for a system-\-on-a\--pro\-grammable-\-chip interconnection.
 Avalon defines an extensive range of interconnection devices, from
 a simple asynchronous interface for direct static RAM
 connection to sophisticated pipeline transfers with variable

--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -24,7 +24,7 @@
 
 
 \newif\ifbook
-%\booktrue % comment out for the print book version
+\booktrue % comment out for the print book version
 
 \ifbook
 \else

--- a/chisel-book.tex
+++ b/chisel-book.tex
@@ -584,7 +584,7 @@ To build hardware for an FPGA, you need a synthesize tool. The two major
 FPGA vendors, Altera, an Intel Company\footnote{former Intel and former Altera}
 and AMD,\footnote{former Xilinx} provide free versions of
 their tools that cover small to medium-sized FPGAs. Those medium-sized
-FPGAs are large enough to build a multicore RISC style processors.
+FPGAs are large enough to build a multicore RISC style processor.
 Intel provides the \myref{https://www.intel.com/content/www/us/en/products/details/fpga/development-tools/quartus-prime/resource.html}{Quartus Prime Lite Edition} and AMD the
 \myref{https://www.xilinx.com/products/design-tools/vivado/vivado-webpack.html}{Vivado Design Suite, WebPACK Edition}.
 Both tools are available for Windows and Linux, but not for macOS.


### PR DESCRIPTION
Hi Martin, 
I found some minor issues in the book that I fixed:
* Typo "processors" -> "processor"
* A word not hyphenated that was creating a rather ugly overfull box
* Spacing in front of footnotemarks
* Spelling mistake in the reference to the Leros ISA table
