### PR TITLE
Make operations a bit more easy to understand for newbies.

### DIFF
--- a/src/main/scala/Logic.scala
+++ b/src/main/scala/Logic.scala
@@ -67,19 +67,19 @@ class Logic extends Module {
   val bop = bt & bf
 
   //- start bool_ops
-  val and = a & b // bitwise and
-  val or = a | b  // bitwise or
-  val xor = a ^ b // bitwise xor
-  val not = ~a    // bitwise negation
+  val a_and_b = a & b // bitwise and of a and b
+  val a_or_b = a | b  // bitwise or of a and b
+  val a_xor_b = a ^ b // bitwise xor of a and b
+  val a_not = ~a    // bitwise negation of a
   //- end
 
   //- start arith_ops
-  val add = a + b // addition
-  val sub = a - b // subtraction
-  val neg = -a    // negate
-  val mul = a * b // multiplication
-  val div = a / b // division
-  val mod = a % b // modulo operation
+  val a_plus_b = a + b // addition of a and b
+  val a_minus_b = a - b // subtraction of b from a
+  val neg_a = -a    // negate a
+  val a_mul_b = a * b // multiplication of a and b
+  val a_div_b = a / b // division of a by b
+  val a_mod_b = a % b // modulo operation of a by b
   //- end
 
   //- start wire


### PR DESCRIPTION
I am suggesting this changes because I think it improves readability a bit.

I have over 40 years experience with C and about 10 years with verilog and VHDL, and close to zero with Scala.

I would think most people reading this book are Scala newbies such as myself.

When I read the book for the first time, I was a bit confused as to what was being explained by the text:

 val and = a & b;

At first I thought the "and" was the operator (like in vhdl), then I realised that and was the name of the value being created here.

I think this would be more immediately understood by using something that is not possible to confuse with an operator. For example:

 val a_and_b = a & b;

This is not a biggie, and maybe not the best way to clarify this, but if it confused me it might confuse others.